### PR TITLE
Updated to support Tsdl 0.9.7

### DIFF
--- a/opam
+++ b/opam
@@ -21,9 +21,9 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "tsdl_mixer"]
 depends: [
+  "ocaml" {>= "4.03.0"}
   "ctypes" {>= "0.4.0"} "ctypes-foreign"
-  "tsdl" {>= "0.9.0" & < "0.9.7"}
-  "result"
+  "tsdl" {>= "0.9.0"}
   "oasis" {build}
 ]
 depexts: [

--- a/src/tsdl_mixer.ml
+++ b/src/tsdl_mixer.ml
@@ -1,7 +1,6 @@
 open Ctypes
 open Foreign
 open Tsdl
-open Result
 
 module Mixer = struct
 


### PR DESCRIPTION
Implements #5. Wanted to use your bindings with 0.9.7 but needed this updated. Think all that needed to be done was remove the `Result` dependency and reflect that in `opam`. Tested compiling and running it in my project it's working.